### PR TITLE
Fix minimum platforms in `Package.swift` to match deps

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 
 let package = Package(
   name: "GoogleAdsOnDeviceConversion",
-  platforms: [.iOS(.v10)],
+  platforms: [.iOS(.v12), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v7)],
   products: [
     .library(
       name: "GoogleAdsOnDeviceConversion",


### PR DESCRIPTION
Updated the minimum platforms listed in `Package.swift` to match the minimums in:
- https://github.com/firebase/firebase-ios-sdk/blob/4f6c342424df416d78dfc12d08c97769fd4e1152/Package.swift#L26
- https://github.com/google/GoogleUtilities/blob/60da361632d0de02786f709bdc0c4df340f7613e/Package.swift#L22
- https://github.com/google/GoogleAppMeasurement/blob/d96c7fd793c8a5344127c838d2b6c9d4f17e790a/Package.swift#L22

This should resolve https://github.com/firebase/firebase-ios-sdk/actions/runs/15205525977/job/42767709247#step:9:376. See https://github.com/firebase/firebase-ios-sdk/pull/14882#issuecomment-2903068933 for more details.